### PR TITLE
Namespaced provides

### DIFF
--- a/src/coldroute.cfc
+++ b/src/coldroute.cfc
@@ -341,4 +341,23 @@
 			return urlFor(argumentCollection=arguments);
 		</cfscript>
 	</cffunction>
+
+	<cffunction name="$generateRenderWithTemplatePath" access="public" output="false" returntype="string" hint="">
+		<cfargument name="controller" type="string" required="true">
+		<cfargument name="action" type="string" required="true">
+		<cfargument name="template" type="string" required="true">
+		<cfargument name="contentType" type="string" required="true">
+		<cfscript>
+			var templateName = "";
+			
+			if (!Len(arguments.template))
+				templateName = "/" & Replace(arguments.controller, ".", "/") & "/" & arguments.action;
+			else
+				templateName = arguments.template;
+				
+			if (Len(arguments.contentType))
+				templateName = templateName & "." & arguments.contentType;
+		</cfscript>
+		<cfreturn templateName />
+	</cffunction>
 </cfcomponent>


### PR DESCRIPTION
This allows for you to use custom templates like `/api/members/index.json.cfm`. Before this change, it was looking for `/api.Members/index.json.cfm`.

If this solution isn't appropriate, at least you're aware of the issue. Feel free to make it better, of course.
